### PR TITLE
Add pagination support (Bash)

### DIFF
--- a/bash/Readme.md
+++ b/bash/Readme.md
@@ -17,6 +17,9 @@ Clone any user's public repositories concurrently.
 2. Enter account name when prompted
 3. Enjoy!
 
+### Run the script with 1 command line argument
+1. Run the script `rm -rf  murjax/; bash cloner.sh murjax`
+
 ### Links for learning
 > Interogate json with jq  
 > https://stackoverflow.com/questions/33950596/iterating-through-json-array-in-shell-script  

--- a/bash/Readme.md
+++ b/bash/Readme.md
@@ -30,3 +30,10 @@ Clone any user's public repositories concurrently.
 > https://unix.stackexchange.com/a/461813/188491  
 > `main () { echo running ... }; time main`
 
+> Check for non-null/non-zero string variable
+> https://stackoverflow.com/a/3601734/5283424
+> `if [ -n "$1" ]`
+
+> Return an exit code
+> https://superuser.com/a/371539/644627
+> `return 1`

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -26,13 +26,9 @@ make_folder () {
 }
 
 clone_repos () {
-  curl -s https://api.github.com/users/$account_name/repos | jq -c '.[]' |
-
-  while read i;
-  do
-    val=$(jq -r '.clone_url' <<< "$i");
-    (git clone -q $val) &> /dev/null & 
-  done;
+  local pagecontents=$(curl -s https://api.github.com/users/$account_name/repos | jq -c '.[]' | jq -r '.clone_url')
+  echo $pagecontents
+  # (git clone -q $pagecontents) &> /dev/null & 
 
   echo -n loading;
 

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -28,7 +28,10 @@ make_folder () {
 clone_repos () {
   local pagecontents=$(curl -s https://api.github.com/users/$account_name/repos | jq -c '.[]' | jq -r '.clone_url')
   echo $pagecontents
-  # (git clone -q $pagecontents) &> /dev/null & 
+  for url in ${pagecontents}; do
+    echo "$url"
+    # (git clone -q $url) &> /dev/null &
+  done
 
   echo -n loading;
 

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -12,11 +12,16 @@
 # https://unix.stackexchange.com/a/461813/188491
 # main () { echo running ... }; time main
 
-ask() {
-  echo "Please enter account_name (user/organization name)";
-  read account_name;
-  echo ;
-  echo "You entered $account_name";
+ask () {
+  if [ -n "$1" ]
+    then # non-null/non-zero string chcek ... aka exists!
+      account_name="$1"
+    else # No argument supplied 
+      echo "Please enter account_name (user/organization name)";
+      read account_name;
+      echo ;
+      echo "You entered $account_name";
+  fi 
 }
 
 make_folder () {
@@ -26,7 +31,8 @@ make_folder () {
 }
 
 check () {
-  if [ -n "$1" ]; then # non-null/non-zero string chcek ... aka exists!
+  if [ -n "$1" ]
+    then # non-null/non-zero string chcek ... aka exists!
       echo "success"
       return 0; # return something similar to an exit code.
     else
@@ -58,5 +64,7 @@ clone_repos () {
   }
 }
 
-ask && make_folder && time clone_repos
+# Provide a username when running the script to bypass the ask prompt.
+# example: rm -rf  murjax/; bash bash/cloner.sh murjax
+ask "$@" && make_folder && time clone_repos
 

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -12,6 +12,14 @@
 # https://unix.stackexchange.com/a/461813/188491
 # main () { echo running ... }; time main
 
+# Check for non-null/non-zero string variable
+# https://stackoverflow.com/a/3601734/5283424
+# `if [ -n "$1" ]`
+
+# Return an exit code
+# https://superuser.com/a/371539/644627
+# `return 1`
+
 ask () {
   if [ -n "$1" ]
     then # non-null/non-zero string chcek ... aka exists!

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -1,6 +1,6 @@
 ## Links
 
-# interogate json with jq
+# interrogate json with jq
 # https://stackoverflow.com/questions/33950596/iterating-through-json-array-in-shell-script
 # echo "$res" | jq -c -r '.[]' | while read item; do     val=$(jq -r '.value' <<< "$item")     echo "Value: $val" done
 
@@ -22,7 +22,7 @@
 
 ask () {
   if [ -n "$1" ]
-    then # non-null/non-zero string chcek ... aka exists!
+    then # non-null/non-zero string check ... aka exists!
       account_name="$1"
     else # No argument supplied 
       echo "Please enter account_name (user/organization name)";
@@ -40,7 +40,7 @@ make_folder () {
 
 check () {
   if [ -n "$1" ]
-    then # non-null/non-zero string chcek ... aka exists!
+    then # non-null/non-zero string check ... aka exists!
       echo "success"
       return 0; # return something similar to an exit code.
     else
@@ -51,15 +51,15 @@ check () {
 
 get_repos_by_page () {
   local page=$1;
-  # resons the curl request to the api can fail:
+  # reasons the curl request to the api can fail:
   # 1. api request limit exceeded, clone_url property will not exist.
   # 2. repository does not exist, clone url property will not exist.
-  local pagecontents=$(curl https://api.github.com/users/$account_name/repos?page=$page | jq -c '.[]' 2>/dev/null | jq -r '.clone_url' 2>/dev/null);
+  local page_contents=$(curl https://api.github.com/users/$account_name/repos?page=$page | jq -c '.[]' 2>/dev/null | jq -r '.clone_url' 2>/dev/null);
 
-  # echo $pagecontents;
-  check $pagecontents &&
+  # echo $page_contents;
+  check $page_contents &&
   {
-    for url in ${pagecontents}; do
+    for url in ${page_contents}; do
       # echo "$url";
       # git clone does not have a rate limiting that I am aware of.
       (git clone -q $url) &> /dev/null &

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -60,7 +60,8 @@ get_repos_by_page () {
   check $page_contents &&
   {
     for url in ${page_contents}; do
-      # echo "$url";
+      echo "$url";
+
       # git clone does not have a rate limiting that I am aware of.
       (git clone -q $url) &> /dev/null &
     done

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -26,7 +26,7 @@ make_folder () {
 }
 
 clone_repos () {
-  local pagecontents=$(curl -s https://api.github.com/users/$account_name/repos | jq -c '.[]' | jq -r '.clone_url')
+  local pagecontents=$(curl -s https://api.github.com/users/$account_name/repos | jq -c '.[]' 2>/dev/null | jq -r '.clone_url' 2>/dev/null)
   echo $pagecontents
   for url in ${pagecontents}; do
     echo "$url"

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -25,24 +25,37 @@ make_folder () {
   echo
 }
 
+check () {
+  if [ -n "$1" ]; then # non-null/non-zero string chcek ... aka exists!
+      echo "success"
+      return 0; # return something similar to an exit code.
+    else
+      echo "error"
+      return 1; # return something similar to an exit code.
+  fi
+}
+
+
 clone_repos () {
   local pagecontents=$(curl -s https://api.github.com/users/$account_name/repos | jq -c '.[]' 2>/dev/null | jq -r '.clone_url' 2>/dev/null)
-  echo $pagecontents
-  for url in ${pagecontents}; do
-    echo "$url"
-    # (git clone -q $url) &> /dev/null &
-  done
+  check $pagecontents &&
+  {
+    for url in ${pagecontents}; do
+      echo "$url"
+      # (git clone -q $url) &> /dev/null &
+    done
 
-  echo -n loading;
+    echo -n loading;
 
-  while
-    echo -n .;
-    ps e | grep -v grep | grep git > /dev/null;
-  do
-    sleep 1;
-  done;
+    while
+      echo -n .;
+      ps e | grep -v grep | grep git > /dev/null;
+    do
+      sleep 1;
+    done;
 
-  echo ;
+    echo ;
+  }
 }
 
 ask && make_folder && time clone_repos


### PR DESCRIPTION
## Features
1. Add pagination support (Bash) 
2. Run the script with 1 command line argument (bash)

## Scaling thoughts:
1. my guess: `git clone` commands will not have a rate limit.
2. rate limiting currently occurs for me when using the `list repos` api request.
This api request may need a delay or sleep for large accounts after a certain page number is hit within a second.

## Future work
1.  Make a throttler for rate limiting the get repos api request.
2.  Handle failure cases.

<img width="700" alt="Screenshot 2023-09-18 at 9 37 09 PM" src="https://github.com/murjax/Github-Repo-Cloner/assets/11463275/163b97fe-12d5-468d-b476-582081fec1b7">
