### PR TITLE
Cleanup status code logic to forward server messages to the user

### DIFF
--- a/bash/Readme.md
+++ b/bash/Readme.md
@@ -58,3 +58,7 @@ Clone any user's public repositories concurrently.
 
 > Parse http_status_code and http_body to two different variables
 > https://superuser.com/a/1805689/644627
+
+> Prefer echoing to stderr instead of standout when logging. This helps you from polluting stdout which is used to send output to another program.
+> echo "I will show in your terminal but will not pollute $*" >&2;
+> Coffee Shop insight! From Trent!

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -116,7 +116,7 @@ handle_status_code () {
       ;;
     *)
       echo "Error, Status code: $http_status";
-      echo "$http_body" | jq -r '.message' 2>/dev/null;
+      echo "$http_body" | jq -r '.message' 2>/dev/null &&
       echo "$http_body" | jq -r '.documentation_url' 2>/dev/null ||
         echo "$http_body";
       return 1; # return error code.

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -149,9 +149,10 @@ get_repos_by_page () {
     echo "$page_content";
     return 1;
   }
-  check $page_content &&
+  local new_content="$page_content"
+  check $new_content &&
   {
-    for url in ${page_content}; do
+    for url in ${new_content}; do
       echo "$url";
 
       # git clone does not have a rate limiting that I am aware of.

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -109,10 +109,16 @@ handle_status_code () {
       echo "Caching Resource: $http_status" >&2;
       return 0; # return success code.
       ;;
+    000)
+      echo "Error, Status code: $http_status";
+      echo "Pro tip: you may not be connected to the internet";
+      return 1; # return error code.
+      ;;
     *)
       echo "Error, Status code: $http_status";
       echo "$http_body" | jq -r '.message' 2>/dev/null;
-      echo "$http_body" | jq -r '.documentation_url' 2>/dev/null;
+      echo "$http_body" | jq -r '.documentation_url' 2>/dev/null ||
+        echo "$http_body";
       return 1; # return error code.
       ;;
   esac
@@ -123,7 +129,7 @@ get_body_from_api_or_handle_error () {
   local URL=https://api.github.com/users/$account_name/repos?page=$page;
 
   # get http_status and http_body from request:
-  local response="$(curl -s -w "%{http_code}\n" $URL)";
+  local response="$(curl -sS -w "%{http_code}\n" $URL 2>&1)";
 
   local http_body="$(echo "$response" | sed '$d')";
   local http_status="$(echo "$response" | tail -n 1)";

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -171,9 +171,9 @@ clone_repos () {
 }
 
 wait_for_git () {
-  echo -n loading;
+  echo -n loading 2>&1;
   while
-    echo -n .;
+    echo -n . 2>&1;
     ps e | grep -v grep | grep git > /dev/null;
   do
     sleep 1;

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -40,8 +40,8 @@
 # Parse http_status_code and http_body to two different variables
 # https://superuser.com/a/1805689/644627
 
-# Always echo to stderr instead of standout unless you want to output something to another program.
-# echo -n "Blah" >&2;
+# Prefer echoing to stderr instead of standout when logging. This helps you from polluting stdout which is used to send output to another program.
+# echo "I will show in your terminal but will not pollute $*" >&2;
 # Coffee Shop insight! From Trent!
 
 ask () {

--- a/bash/cloner.sh
+++ b/bash/cloner.sh
@@ -162,6 +162,7 @@ get_repos_by_page () {
     # recurse and go to the next page number until no repos come back. This might need a delay or sleep for large accounts.
     get_repos_by_page $((page+1));
   } || return 0; # return success code regardless and let the program continue.
+  # if [ $page -eq 1 ]; then wait_for_git & fi; <- TODO, for starting the wait sooner.
   unset $page_content
 }
 
@@ -182,5 +183,5 @@ wait_for_git () {
 # get_body_from_api_or_handle_error
 # Provide a username when running the script to bypass the ask prompt.
 # example: rm -rf  murjax/; bash bash/cloner.sh murjax
-ask "$@" && make_folder && clone_repos && time wait_for_git && cd ..;
+time (ask "$@" && make_folder && clone_repos && wait_for_git && cd ..);
 


### PR DESCRIPTION
## Bonus
Today I learned,  prefer echoing to stderr instead of standout when logging
This helps you from polluting stdout which is used to send output to another program.
Or when sending an output from one function to another!

This was a coffee shop insight from a zsh scripter named Trent a coffee shop!

example: `echo "I will show in your terminal but will not pollute $*" >&2;`
# Coffee Shop insight! From Trent!

# Error Example:
<img width="1262" alt="Screenshot 2023-09-26 at 3 35 42 PM" src="https://github.com/murjax/Github-Repo-Cloner/assets/11463275/fe10cb04-a4d6-4503-ba14-e9b5f96df001">

# Success Example:
<img width="568" alt="Screenshot 2023-09-26 at 3 34 18 PM" src="https://github.com/murjax/Github-Repo-Cloner/assets/11463275/33d059db-c10f-44a7-a765-817be081798d">
