### PR TITLE
.gitignore updates to ignore submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,7 @@
-# The directory Mix will write compiled artifacts to.
-/_build/
-
-# If you run "mix test --cover", coverage assets end up here.
-/cover/
-
-# The directory Mix downloads your dependencies sources to.
-/deps/
-
-# Where 3rd-party dependencies like ExDoc output generated docs.
-/doc/
-
-# Ignore .fetch files in case you like to edit your project deps locally.
-/.fetch
-
-# If the VM crashes, it generates a dump, let's ignore it too.
-erl_crash.dump
-
-# Also ignore archive artifacts (built via "mix archive.build").
-*.ez
+**/*
+!*.*
+!bash
+!elixir
+!python
+!ruby
+!old


### PR DESCRIPTION
This turns out to be an oddly hard problem.

I did not see any resources online with a solution that lets you ignore an entire folder based on the presence of a child file or child folder. In this case we would want to ignore any subfolders from tracking that contained .git folders.

So I went to the .gitignore docs. and learned you can do negation tracking with `!`
https://git-scm.com/docs/gitignore

There may be a better solution but this is the best I can come up with right now.
and should work for this project right now as long as we are mindful of whenever we need a new directory we need to opt into it in the gitignore by adding a negation.